### PR TITLE
Fix resume language donut arc calculation

### DIFF
--- a/layouts/partials/blocks/resume-languages.html
+++ b/layouts/partials/blocks/resume-languages.html
@@ -20,6 +20,10 @@
   <div class="flex items-center flex-col lg:flex-row gap-x-8">
     {{ range $langs }}
       {{ $pct := float .percent }}
+      {{ $radius := 120.0 }}
+      {{ $circumference := mul 2.0 (mul math.Pi $radius) }}
+      {{ $progress := mul (div $pct 100.0) $circumference }}
+      {{ $gap := sub $circumference $progress }}
       <div class="flex flex-col items-center">
         <div class="flex items-center justify-center w-28 h-28">
           <svg class="transform -rotate-90" viewBox="0 0 288 288">
@@ -27,8 +31,7 @@
                     fill="transparent" class="text-gray-200 dark:text-gray-700" />
             <circle cx="145" cy="145" r="120" stroke="currentColor" stroke-width="30"
                     fill="transparent" class="text-primary-600 dark:text-primary-300"
-                    pathLength="100"
-                    style="stroke-dasharray: 100; stroke-dashoffset: {{ printf "%.2f" (sub 100.0 $pct) }}" />
+                    style="stroke-dasharray: {{ printf "%.2f %.2f" $progress $gap }}; stroke-dashoffset: 0" />
           </svg>
           <span class="absolute text-3xl">{{ .percent }}%</span>
         </div>

--- a/layouts/partials/blox/resume-languages/block.html
+++ b/layouts/partials/blox/resume-languages/block.html
@@ -20,6 +20,10 @@
   <div class="flex items-center flex-col lg:flex-row gap-x-8">
 {{ range $langs }}
   {{ $pct := float .percent }}
+  {{ $radius := 120.0 }}
+  {{ $circumference := mul 2.0 (mul math.Pi $radius) }}
+  {{ $progress := mul (div $pct 100.0) $circumference }}
+  {{ $gap := sub $circumference $progress }}
       <div class="flex flex-col items-center">
         <div class="flex items-center justify-center w-28 h-28">
           <svg class="transform -rotate-90" viewBox="0 0 288 288">
@@ -29,9 +33,8 @@
             <!-- Fortschritt -->
             <circle cx="145" cy="145" r="120" stroke="currentColor" stroke-width="30"
                     class="text-primary-600 dark:text-primary-300" fill="transparent"
-                    pathLength="100"
-                    style="stroke-dasharray: 100;
-                          stroke-dashoffset: {{ printf "%.2f" (sub 100.0 $pct) }}" />
+                    style="stroke-dasharray: {{ printf "%.2f %.2f" $progress $gap }};
+                          stroke-dashoffset: 0" />
           </svg>
           <span class="absolute text-3xl">{{ .percent }}%</span>
         </div>


### PR DESCRIPTION
## Summary
- compute the donut arc length from the circle circumference so the stroke matches the language percentage
- apply the same calculation in both resume languages partial overrides to keep them aligned

## Testing
- pnpm run build *(fails: pnpm package download is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d37859fcf08320a964a8a9aeadbb68